### PR TITLE
feat: save TradeList to DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/project/stocker/StockerApplication.java
+++ b/src/main/java/com/project/stocker/StockerApplication.java
@@ -3,8 +3,10 @@ package com.project.stocker;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@EnableJpaAuditing
+@SpringBootApplication
 public class StockerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project/stocker/configure/WebSecurityConfig.java
+++ b/src/main/java/com/project/stocker/configure/WebSecurityConfig.java
@@ -56,6 +56,8 @@ public class WebSecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
                         .requestMatchers("/api/user/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/api/stock/crawling").permitAll()
+                        .requestMatchers("/api/stock/crawling/save").permitAll()
                         .requestMatchers("/api/user/logout").authenticated()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );

--- a/src/main/java/com/project/stocker/configure/WebSecurityConfig.java
+++ b/src/main/java/com/project/stocker/configure/WebSecurityConfig.java
@@ -56,8 +56,6 @@ public class WebSecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
                         .requestMatchers("/api/user/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
-                        .requestMatchers("/api/stock/crawling").permitAll()
-                        .requestMatchers("/api/stock/crawling/save").permitAll()
                         .requestMatchers("/api/user/logout").authenticated()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );

--- a/src/main/java/com/project/stocker/dto/request/TradeDto.java
+++ b/src/main/java/com/project/stocker/dto/request/TradeDto.java
@@ -1,10 +1,17 @@
 package com.project.stocker.dto.request;
 
+import com.project.stocker.entity.Stock;
 import lombok.Getter;
 
 @Getter
 public class TradeDto {
     private long quantity;
     private long price;
-    private String status;
+    private Stock stock;
+
+    public TradeDto(long quantity, long price, Stock stock) {
+        this.quantity = quantity;
+        this.price = price;
+        this.stock = stock;
+    }
 }

--- a/src/main/java/com/project/stocker/entity/Buy.java
+++ b/src/main/java/com/project/stocker/entity/Buy.java
@@ -1,5 +1,6 @@
 package com.project.stocker.entity;
 
+import com.project.stocker.util.Auditing;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @Table
 @NoArgsConstructor
 @AllArgsConstructor
-public class Buy {
+public class Buy extends Auditing {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
@@ -29,20 +30,19 @@ public class Buy {
     @Column
     private String status;
 
-    @CreatedDate
-    @Column(updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createdAt;
+    @ManyToOne
+    @JoinColumn(name = "stock_id")
+    private Stock stock;
 
-    @LastModifiedDate
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime updatedAt;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
-//    @ManyToOne
-//    @JoinColumn(name = "stock_id")
-//    private Stock stock;
-
-//    @ManyToOne
-//    @JoinColumn(name = "user_id")
-//    private User user;
+    public Buy(Long quantity, Long price, Stock stock, User user) {
+        this.quantity = quantity;
+        this.price = price;
+        this.status = "done";
+        this.stock = stock;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/project/stocker/entity/Sell.java
+++ b/src/main/java/com/project/stocker/entity/Sell.java
@@ -1,5 +1,6 @@
 package com.project.stocker.entity;
 
+import com.project.stocker.util.Auditing;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @Table
 @NoArgsConstructor
 @AllArgsConstructor
-public class Sell {
+public class Sell extends Auditing {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
@@ -29,20 +30,19 @@ public class Sell {
     @Column
     private String status;
 
-    @CreatedDate
-    @Column(updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createdAt;
+    @ManyToOne
+    @JoinColumn(name = "stock_id")
+    private Stock stock;
 
-    @LastModifiedDate
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime updatedAt;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
-//    @ManyToOne
-//    @JoinColumn(name = "stock_id")
-//    private Stock stock;
-//
-//    @ManyToOne
-//    @JoinColumn(name = "user_id")
-//    private User user;
+    public Sell(Long quantity, Long price, Stock stock, User user) {
+        this.quantity = quantity;
+        this.price = price;
+        this.status = "done";
+        this.stock = stock;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/project/stocker/entity/Stock.java
+++ b/src/main/java/com/project/stocker/entity/Stock.java
@@ -25,6 +25,12 @@ public class Stock {
     @Column(nullable = false)
     private String status;
 
+    @OneToMany(mappedBy = "stock")
+    private List<Buy> buys = new ArrayList<>();
+
+    @OneToMany(mappedBy = "stock")
+    private List<Sell> sells = new ArrayList<>();
+
     public Stock(String company, String code) {
         this.company = company;
         this.code = code;

--- a/src/main/java/com/project/stocker/entity/User.java
+++ b/src/main/java/com/project/stocker/entity/User.java
@@ -5,6 +5,10 @@ import com.project.stocker.util.Auditing;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.w3c.dom.stylesheets.LinkStyle;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,6 +31,12 @@ public class User extends Auditing {
     private String email;
 
     private boolean status;
+
+    @OneToMany(mappedBy = "user")
+    private List<Buy> buys = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Sell> sells = new ArrayList<>();
 
     public User(String username, String password, String email, UserRoleEnum role) {
         this.username = username;

--- a/src/main/java/com/project/stocker/service/BuyService.java
+++ b/src/main/java/com/project/stocker/service/BuyService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BuyService {
 //    private final StockService stockService;
 //    private final UserService userService;
-    private final BuyService buyService;
+//    private final BuyService buyService;
 
     public static BuyCreateDto buyCreate(com.project.stocker.dto.request.BuyCreateDto buyCreateDto){
 

--- a/src/main/java/com/project/stocker/service/SellService.java
+++ b/src/main/java/com/project/stocker/service/SellService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellService {
 //    private final StockService stockService;
 //    private final UserService userService;
-    private final SellService sellService;
+//    private final SellService sellService;
 
 
     public SellCreateDto sellCreate(com.project.stocker.dto.request.SellCreateDto sellCreateDto) {

--- a/src/main/java/com/project/stocker/service/StockService.java
+++ b/src/main/java/com/project/stocker/service/StockService.java
@@ -1,7 +1,11 @@
 package com.project.stocker.service;
 
-import com.project.stocker.entity.Stock;
+import com.project.stocker.dto.request.TradeDto;
+import com.project.stocker.entity.*;
+import com.project.stocker.repository.BuyRepository;
+import com.project.stocker.repository.SellRepository;
 import com.project.stocker.repository.StockRepository;
+import com.project.stocker.repository.UserRepository;
 import com.project.stocker.util.JsoupCrawling;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +18,9 @@ public class StockService {
 
     private final StockRepository stockRepository;
     private final JsoupCrawling jsoupCrawling;
+    private final BuyRepository buyRepository;
+    private final SellRepository sellRepository;
+    private final UserRepository userRepository;
 
     public void saveStockList() {
         List<Stock> stocks = jsoupCrawling.getStocks();
@@ -21,8 +28,13 @@ public class StockService {
     }
 
     public void saveTradeList() {
+        User user = userRepository.findById(1L).orElseThrow(()->
+                new IllegalArgumentException("id가 1인 유저가 존재하지 않습니다."));
         List<Stock> stocks = stockRepository.findAll();
-        jsoupCrawling.getTrades(stocks);
+        List<TradeDto> trades = jsoupCrawling.getTrades(stocks);
+        List<Buy> buys = trades.parallelStream().map((tradeDto -> new Buy(tradeDto.getQuantity(), tradeDto.getPrice(), tradeDto.getStock(), user))).toList();
+        List<Sell> sells = trades.parallelStream().map((tradeDto -> new Sell(tradeDto.getQuantity(), tradeDto.getPrice(), tradeDto.getStock(), user))).toList();
+        buyRepository.saveAll(buys);
+        sellRepository.saveAll(sells);
     }
-
 }


### PR DESCRIPTION
issue #9 

Stock테이블에 저장된 모든 주식들에 대해 2023년 08월 09일자 1분당 거래량, 거래 가격을 DB에 저장

- Buy, Sell엔티티의 연관관계 설정(Stock, User)
- Auditing 상속
- Stock 테이블에 저장된 주식의 종목코드를 사용하여 크롤링을 통해 해당 주식의 1분당 거래량, 거래가격을 얻어와 TradeDto 생성
- StockService.saveTradeList()는 생성된 Dto의 List를 반환받아 Buy, Sell엔티티로 변환
- 각각 Buy, Sell테이블에 저장