### PR TITLE
feat: cors & security config

### DIFF
--- a/src/main/java/com/project/stocker/configure/WebMvcConfig.java
+++ b/src/main/java/com/project/stocker/configure/WebMvcConfig.java
@@ -1,0 +1,40 @@
+package com.project.stocker.configure;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowCredentials(true)
+                .allowedHeaders("*")
+                .allowedOrigins("https://stocker9.shop", "https://stocker9.shop:8080", "https://stocker9.shop:8081")
+                .exposedHeaders("Authorization", "Refresh-Token")
+                .allowedMethods("OPTIONS", "GET", "POST", "PUT", "DELETE")
+                .maxAge(3000);
+    }
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(new HandlerInterceptor() {
+            @Override
+            public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+                return HandlerInterceptor.super.preHandle(request, response, handler);
+            }
+
+            @Override
+            public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+                HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+            }
+        });
+    }
+}

--- a/src/main/java/com/project/stocker/configure/WebSecurityConfig.java
+++ b/src/main/java/com/project/stocker/configure/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -58,6 +59,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/user/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
                         .requestMatchers("/actuator").permitAll()
                         .requestMatchers("/actuator/prometheus").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/**").permitAll()
                         .requestMatchers("/api/user/logout").authenticated()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );


### PR DESCRIPTION
#21 
https://github.com/team9-be/stocker-be/issues/21
WebMvcConfig
도메인 발급 및 https 적용을 위한
cors 설정
Security config
GET메소드에는 security가
필요하지 않아서 GET 메소드에 대한
시큐리티 요청을 없앰