### PR TITLE
feat: optimize crawling stock trade data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 ### VS Code ###
 .vscode/
 .DS_Store
+
+### log ###
+logs/

--- a/src/main/java/com/project/stocker/util/JsoupCrawling.java
+++ b/src/main/java/com/project/stocker/util/JsoupCrawling.java
@@ -48,7 +48,8 @@ public class JsoupCrawling {
         List<TradeDto> trades = new ArrayList<>();
         for (Stock stock : stocks) {
             for (int i = 1; i < 41; i++) {
-                Connection conn = Jsoup.connect(TRADE_URL_BASE + "code=" + stock.getCode() + "&thistime=20230809162200&page=" + i);
+                Connection conn = Jsoup.connect(TRADE_URL_BASE + "code=" + stock.getCode() + "&thistime=20230818162200&page=" + i);
+                int index = 0;
 
                 try {
                     Document document = conn.get();
@@ -63,11 +64,14 @@ public class JsoupCrawling {
 
                         if (!price.equals("") && !quantity.equals("")) {
                             trades.add(new TradeDto(Long.parseLong(quantity), Long.parseLong(price), stock));
+                            index++;
                         }
                     }
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
+                if(index < 10)
+                    break;
             }
         }
         return trades;


### PR DESCRIPTION
issue #32 

주식 거래 데이터 크롤링 최적화

기존의 거래내역 데이터가 모자란 주식에 대해 40페이지 모두 크롤링 하던것에서 
거래내역이 존재하는 만큼만 크롤링 하도록 코드 변경

추가로 로그파일 gitignore에 추가